### PR TITLE
Revamp hill easing and add new road profiles

### DIFF
--- a/outrun-v1.html
+++ b/outrun-v1.html
@@ -374,7 +374,7 @@
 
   let segments=[], trackLength=0;
 
-  function addSegment(curve, y, hillMult = 1, features = {}){
+  function addSegment(curve, y, features = {}){
     const n=segments.length;
     const prevY = segments.length ? segments[n-1].p2.world.y : 0;
     const featureClone = { ...features };
@@ -384,7 +384,6 @@
     segments.push({
       index:n,
       curve,
-      hillMult,
       features: featureClone,
       p1:{ world:{ y: prevY, z:n*segmentLength }, camera:{}, screen:{} },
       p2:{ world:{ y:y,                                      z:(n+1)*segmentLength }, camera:{}, screen:{} },
@@ -393,24 +392,48 @@
   }
 
   const easeIn    = (a,b,t) => a + (b-a) * (t*t);
+  const easeOut   = (a,b,t) => {
+    const tt = t < 0 ? 0 : (t > 1 ? 1 : t);
+    const inv = 1 - tt;
+    return a + (b - a) * (1 - inv * inv);
+  };
   const easeInOut = (a,b,t) => {
-    t *= 2;
-    if (t < 1) return a + (b-a)/2 * (t*t);
-    t -= 1;
-    return a + (b-a)/2 * ((t * (t - 2)) + 1);
+    let tt = t < 0 ? 0 : (t > 1 ? 1 : t);
+    tt *= 2;
+    if (tt < 1) return a + (b-a)/2 * (tt*tt);
+    tt -= 1;
+    return a + (b-a)/2 * (1 - (tt * (tt - 2)));
+  };
+
+  const clamp01 = (t) => (t < 0 ? 0 : (t > 1 ? 1 : t));
+  const easeOutUnit = (t) => easeOut(0, 1, clamp01(t));
+  const easeInOutUnit = (t) => easeInOut(0, 1, clamp01(t));
+
+  const heightProfiles = {
+    linear: (t) => clamp01(t),
+    smooth: (t) => easeInOutUnit(t),
+    sharp:  (t) => {
+      const tt = clamp01(t);
+      if (tt <= 0.5) {
+        return 0.5 * easeOutUnit(tt * 2);
+      }
+      return 1 - 0.5 * easeOutUnit((1 - tt) * 2);
+    },
   };
 
   function lastY(){
     return segments.length ? segments[segments.length-1].p2.world.y : 0;
   }
 
-  function addRoad(enter, hold, leave, curve, dyInSegments = 0, hillMult = 1, featurePayload = {}){
+  function addRoad(enter, hold, leave, curve, dyInSegments = 0, elevationProfile = 'smooth', featurePayload = {}){
     const e = Math.max(0, enter|0), h = Math.max(0, hold|0), l = Math.max(0, leave|0);
     const total = e + h + l;
     if (total <= 0) return;
 
     const startY = lastY();
     const endY   = startY + (dyInSegments * segmentLength);
+
+    const heightProfile = heightProfiles[elevationProfile] || heightProfiles.smooth;
 
     const extras = { ...featurePayload };
     const railPresent = ('rail' in extras) ? !!extras.rail : true;
@@ -428,12 +451,6 @@
     }
 
     const hasElevationChange = dyInSegments !== 0;
-    const effectiveHillMult = hillMult > 0 ? hillMult : 1;
-    const shapeProgress = (tRaw) => {
-      if (!hasElevationChange || effectiveHillMult === 1) return tRaw;
-      const t = tRaw < 0 ? 0 : (tRaw > 1 ? 1 : tRaw);
-      return Math.pow(t, effectiveHillMult);
-    };
 
     const buildFeatures = (segOffset) => {
       const segFeatures = { ...extras, rail: railPresent };
@@ -445,28 +462,31 @@
     };
 
     let segOffset = 0;
-    const computeY = (progressRaw) => easeInOut(startY, endY, shapeProgress(progressRaw));
+    const computeY = (progressRaw) => {
+      const shaped = hasElevationChange ? heightProfile(progressRaw) : 0;
+      return lerp(startY, endY, shaped);
+    };
 
     for (let n = 0; n < e; n++){
       const tCurve = e > 0 ? n / e : 1;
       addSegment(easeIn(0, curve, tCurve),
                  computeY((0 + n) / total),
-                 hillMult, buildFeatures(segOffset));
+                 buildFeatures(segOffset));
       segOffset++;
     }
 
     for (let n = 0; n < h; n++){
       addSegment(curve,
                  computeY((e + n) / total),
-                 hillMult, buildFeatures(segOffset));
+                 buildFeatures(segOffset));
       segOffset++;
     }
 
     for (let n = 0; n < l; n++){
       const tCurve = l > 0 ? n / l : 1;
-      addSegment(easeInOut(curve, 0, tCurve),
+      addSegment(easeOut(curve, 0, tCurve),
                  computeY((e + h + n) / total),
-                 hillMult, buildFeatures(segOffset));
+                 buildFeatures(segOffset));
       segOffset++;
     }
   }
@@ -486,19 +506,29 @@
       const n = parseFloat(v);
       return Number.isNaN(n) ? d : n;
     };
+    const boolTrueTokens = ['1','true','yes','y','on'];
+    const boolFalseTokens = ['0','false','no','n','off'];
+    const boolWordTokens = ['true','yes','y','on','false','no','n','off'];
     const toBool = (v, d=true) => {
       if (v === '' || v == null) return d;
       const norm = v.toLowerCase();
-      if (['1','true','yes','y','on'].includes(norm)) return true;
-      if (['0','false','no','n','off'].includes(norm)) return false;
+      if (boolTrueTokens.includes(norm)) return true;
+      if (boolFalseTokens.includes(norm)) return false;
       return d;
+    };
+    const isBoolToken = (v) => {
+      if (v === '' || v == null) return false;
+      const norm = v.toLowerCase();
+      return boolWordTokens.includes(norm);
     };
 
     const typeAliases = {
       road: 'road', r: 'road',
       straight: 'straight', flat: 'straight', s: 'straight',
       curve: 'curve', c: 'curve', turn: 'curve',
-      hill: 'hill', h: 'hill', rise: 'hill'
+      hill: 'smoothHill', h: 'smoothHill', rise: 'smoothHill',
+      smoothhill: 'smoothHill', smooth: 'smoothHill',
+      sharphill: 'sharpHill', sharp: 'sharpHill'
     };
 
     const lines = text.split(/\r?\n/);
@@ -513,17 +543,32 @@
       const enter = cells[1];
       const hold = cells[2];
       const leave = cells[3];
-      let hillMultRaw = cells[4];
-      let curveRaw = cells[5];
-      let dyRaw = cells[6];
-      let railRaw = cells[7];
-      let boostStartRaw = cells[8];
-      let boostEndRaw = cells[9];
-      let repeatsRaw = cells[10];
+      let curveRaw;
+      let dyRaw;
+      let railRaw;
+      let boostStartRaw;
+      let boostEndRaw;
+      let repeatsRaw;
+
+      if (isBoolToken(cells[7])) {
+        // Legacy format with hillMult column present
+        curveRaw = cells[5];
+        dyRaw = cells[6];
+        railRaw = cells[7];
+        boostStartRaw = cells[8];
+        boostEndRaw = cells[9];
+        repeatsRaw = cells[10];
+      } else {
+        curveRaw = cells[4];
+        dyRaw = cells[5];
+        railRaw = cells[6];
+        boostStartRaw = cells[7];
+        boostEndRaw = cells[8];
+        repeatsRaw = cells[9];
+      }
 
       if (repeatsRaw === undefined){
         // Legacy format: type, enter, hold, leave, curve, dy, repeats[, comment]
-        hillMultRaw = '';
         curveRaw = cells[4];
         dyRaw = cells[5];
         repeatsRaw = cells[6];
@@ -537,7 +582,6 @@
       const e = Math.max(0, toInt(enter, 0));
       const h = Math.max(0, toInt(hold, 0));
       const l = Math.max(0, toInt(leave, 0));
-      const hillMult = Math.max(0, toFloat(hillMultRaw, 1));
       let c = toFloat(curveRaw, 0);
       let y = toFloat(dyRaw, 0);
       const rail = toBool(railRaw, true);
@@ -545,8 +589,21 @@
       const boostEnd = (boostEndRaw === '' || boostEndRaw == null) ? null : toInt(boostEndRaw, null);
       const reps = Math.max(1, toInt(repeatsRaw, 1));
 
-      if (type === 'straight'){ c = 0; y = 0; }
-      else if (type === 'curve' && (dyRaw === '' || dyRaw == null)) { y = 0; }
+      let elevationProfile = 'smooth';
+
+      if (type === 'straight'){
+        c = 0;
+        elevationProfile = 'linear';
+      }
+      else if (type === 'curve' && (dyRaw === '' || dyRaw == null)) {
+        y = 0;
+      }
+      else if (type === 'smoothHill'){
+        elevationProfile = 'smooth';
+      }
+      else if (type === 'sharpHill'){
+        elevationProfile = 'sharp';
+      }
 
       const features = { rail };
       if (boostStart != null && boostEnd != null && boostEnd >= boostStart) {
@@ -556,7 +613,7 @@
       }
 
       for (let i=0;i<reps;i++){
-        addRoad(e, h, l, c, y, hillMult, features);
+        addRoad(e, h, l, c, y, elevationProfile, features);
       }
     }
 
@@ -1650,11 +1707,11 @@
     } catch (err) {
       console.warn('CSV build failed, using fallback', err);
       segments.length = 0;
-      addRoad(25,25,25,0,0,1);
-      addRoad(50,50,50,2,20,1);
-      addRoad(40,40,40,0,60,1);
-      addRoad(100,80,60,-4,-20,1);
-      addRoad(25,25,25,0,0,1);
+      addRoad(25,25,25,0,0,'smooth');
+      addRoad(50,50,50,2,20,'smooth');
+      addRoad(40,40,40,0,60,'smooth');
+      addRoad(100,80,60,-4,-20,'smooth');
+      addRoad(25,25,25,0,0,'smooth');
       trackLength = segments.length * segmentLength;
     }
 

--- a/tracks/test-track.csv
+++ b/tracks/test-track.csv
@@ -1,7 +1,7 @@
-# Columns: type,enter,hold,leave,hillmult,curve,dy,railpresent,boostStart,boostEnd,repeats[,comment]
-# hillmult>1 sharpens elevation easing when dy ≠ 0. Set railpresent=false to drop guardrails for that build step.
+# Columns: type,enter,hold,leave,curve,dy,railpresent,boostStart,boostEnd,repeats[,comment]
+# Set railpresent=false to drop guardrails for that build step. Hill types: smoothHill (eased), sharpHill (mirrored sharp), straight (linear grade).
 # Provide a boost window via boostStart/boostEnd (segment offsets within the generated block) to auto-spawn pickups and apply the boost multiplier.
-hill,40,40,0,1,0,20,false,0,0,1,big hill with sharper crest
-hill,40,40,20,1,0,20,false,0,0,1,big hill with sharper crest
-hill,20,40,40,1,0,20,false,0,0,1,big hill with sharper crest
-hill,10,40,40,1,0,20,false,0,0,1,big hill with sharper crest
+smoothHill,40,40,0,0,20,false,0,0,1,long smooth climb
+smoothHill,40,40,20,0,-20,false,0,0,1,long smooth descent
+sharpHill,20,20,20,0,15,true,0,0,1,sharper crest for jump
+straight,20,60,20,0,10,true,0,0,1,linear rise without easing


### PR DESCRIPTION
## Summary
- replace the old hillMult exponent with named elevation profiles backed by corrected easing helpers
- update the CSV loader and fallback builder to pick linear, smooth, or sharp elevation behavior based on the road type while keeping legacy rows readable
- refresh the sample track CSV to demonstrate the new smoothHill, sharpHill, and straight modes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d346daf694832d9c1783d0d4b77d40