### PR TITLE
Expand boost zone quads to hide seams

### DIFF
--- a/outrun-v1.html
+++ b/outrun-v1.html
@@ -1196,9 +1196,15 @@
         x3: farMax,  y3: yFar,
         x4: farMin,  y4: yFar,
       };
+      const padded = padQuad(quad, {
+        padLeft:   OVERLAP.x,
+        padRight:  OVERLAP.x,
+        padTop:    OVERLAP.y,
+        padBottom: OVERLAP.y,
+      });
       const colors = BOOST_ZONE_COLORS[zone.type] || BOOST_ZONE_FALLBACK_COLOR;
       const solid = Array.isArray(colors.solid) ? colors.solid : BOOST_ZONE_FALLBACK_COLOR.solid;
-      glr.drawQuadSolid(quad, solid, fogRoad);
+      glr.drawQuadSolid(padded, solid, fogRoad);
     }
   }
 


### PR DESCRIPTION
## Summary
- pad boost zone quads using the shared overlap margins before drawing them
- render the padded quad to cover minor rounding gaps above the road surface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3f682923c832da7c2567b5f920afe