### PR TITLE
Fix cliff additive tilt orientation

### DIFF
--- a/outrun-v1.html
+++ b/outrun-v1.html
@@ -1571,7 +1571,7 @@
     if (!seg) return 0;
     const segT = clamp01((phys.s - seg.p1.world.z) / segmentLength);
     const slope = cliffLateralSlopeAt(seg.index, playerN, segT);
-    const angleDeg = (180 / Math.PI) * Math.atan(slope);
+    const angleDeg = -(180 / Math.PI) * Math.atan(slope);
     return clamp(cfgTilt.tiltDir * angleDeg, -cfgTiltAdd.tiltAddMaxDeg, cfgTiltAdd.tiltAddMaxDeg);
   }
 


### PR DESCRIPTION
## Summary
- invert the additive cliff tilt angle so the player leans into the slope instead of away from it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4b6092248832d8192ea18d9c174e3