### PR TITLE
Disable caching when loading CSV assets for track and cliffs

### DIFF
--- a/outrun-v1.html
+++ b/outrun-v1.html
@@ -630,7 +630,7 @@
   }
 
   async function buildTrackFromCSV(url){
-    const res = await fetch(url);
+    const res = await fetch(url, { cache: 'no-store' });
     if (!res.ok) throw new Error('CSV load failed: ' + res.status);
     const text = await res.text();
 
@@ -796,7 +796,7 @@
 
     let text='';
     try {
-      const res = await fetch(url);
+      const res = await fetch(url, { cache: 'no-store' });
       if (!res.ok) throw new Error('HTTP '+res.status);
       text = await res.text();
     } catch (e) {


### PR DESCRIPTION
## Summary
- disable HTTP caching when loading the track CSV so edits always reload
- apply the same cache bypass to the cliff CSV loader

## Testing
- not run (HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68d4bfa09808832d8dda0d6f18b1e52a