### PR TITLE
Allow unlimited cliff tilt

### DIFF
--- a/outrun-v1.html
+++ b/outrun-v1.html
@@ -172,7 +172,7 @@
   const cfgTilt = { tiltMaxDeg: 45, tiltSens: -3, tiltCurveWeight: -.2, tiltEase: 0.08, tiltDir: 1 };
   let camRollDeg = 0, playerTiltDeg = 0, prevPlayerN = 0, lateralRate = 0;
 
-  const cfgTiltAdd = { tiltAddEnabled: true, tiltAddMaxDeg: 10 };
+  const cfgTiltAdd = { tiltAddEnabled: true, tiltAddMaxDeg: null };
 
   // ---------- Canvas / GL ----------
   const c3D   = document.getElementById('outrun');
@@ -1619,7 +1619,9 @@
       slope = slopeB;
     }
     const angleDeg = -(180 / Math.PI) * Math.atan(slope);
-    return clamp(cfgTilt.tiltDir * angleDeg, -cfgTiltAdd.tiltAddMaxDeg, cfgTiltAdd.tiltAddMaxDeg);
+    const tiltDeg = cfgTilt.tiltDir * angleDeg;
+    if (cfgTiltAdd.tiltAddMaxDeg == null) return tiltDeg;
+    return clamp(tiltDeg, -cfgTiltAdd.tiltAddMaxDeg, cfgTiltAdd.tiltAddMaxDeg);
   }
 
   // ---------- NPCs ----------


### PR DESCRIPTION
## Summary
- allow the additive tilt calculation to return the full cliff-derived angle
- gate the tilt clamping on an optional limit so cliffs can lean the car beyond the old cap

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d4d95ceb00832dbcb9beeacb6d7496