### PR TITLE
Add configurable speed impulse for boost zones

### DIFF
--- a/outrun-v1.html
+++ b/outrun-v1.html
@@ -108,6 +108,10 @@
     boostLockAgainst: 0.25
   };
 
+  const BOOST_ZONE_EFFECT = {
+    speedAdd: 1500,
+  };
+
   const BOOST_ZONE_TYPES = { JUMP: 'jump', DRIVE: 'drive' };
   const BOOST_ZONE_FALLBACK_COLOR = {
     fill: 'rgb(255,255,255)',
@@ -1315,7 +1319,15 @@
   function applyJumpZoneBoost(zone){
     if (!zone) return;
     boostTimer = Math.max(boostTimer, DRIFT.boostTime);
+    applyBoostImpulse();
     phys.boostFlashTimer = Math.max(phys.boostFlashTimer, 0.3);
+  }
+
+  function applyBoostImpulse(){
+    const boostCap = TUNE_PLAYER.maxSpeed * DRIFT.boostMult;
+    const currentForward = Math.max(phys.vtan, 0);
+    const boosted = currentForward + BOOST_ZONE_EFFECT.speedAdd;
+    phys.vtan = clamp(boosted, 0, boostCap);
   }
 
   const input = { left:false,right:false,up:false,down:false, hop:false };
@@ -1427,6 +1439,7 @@
       if (driveZoneHere) {
         if (activeDriveZoneId !== driveZoneHere.id) {
           boostTimer = Math.max(boostTimer, DRIFT.boostTime);
+          applyBoostImpulse();
           activeDriveZoneId = driveZoneHere.id;
         }
       } else {


### PR DESCRIPTION
## Summary
- add a BOOST_ZONE_EFFECT constant to configure the drive/jump speed impulse
- apply the impulse when entering drive zones and jump zones so boosts add immediate speed

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4e564daec832d836898bf78ed8a6b