### PR TITLE
Clear per-segment cars before respawning traffic

### DIFF
--- a/outrun-v1.html
+++ b/outrun-v1.html
@@ -1747,7 +1747,14 @@
     }
     return base;
   }
+  function clearSegmentCars(){
+    for (let i = 0; i < segments.length; i++){
+      const seg = segments[i];
+      if (seg && seg.cars) seg.cars.length = 0;
+    }
+  }
   function spawnCars(){
+    clearSegmentCars();
     cars.length = 0;
     for (let i=0;i<NPC.total;i++){
       const s = Math.floor(Math.random() * Math.max(1, segments.length)) * segmentLength;
@@ -2479,6 +2486,8 @@
       addRoad(25,25,25,0,0,'smooth');
       trackLength = segments.length * segmentLength;
     }
+
+    clearSegmentCars();
 
     // NEW: prepare per-segment cliff arrays and load compact CSV
     resetCliffSeries();


### PR DESCRIPTION
## Summary
- add a helper to clear the per-segment car arrays before spawning new traffic
- invoke the helper in spawnCars and resetScene to avoid stale car references

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbf271fc28832dbbadf51022786c1d