### PR TITLE
Add bootstrap script for renderer setup

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -1,0 +1,50 @@
+const dom = {
+  c3D: document.getElementById('outrun'),
+  cSide: document.getElementById('sideOverlay'),
+  cHUD: document.getElementById('hudMatte'),
+};
+
+const glr = new RenderGL.GLRenderer(dom.c3D);
+
+await (async function loadAssets() {
+  await Promise.all(
+    Object.entries(World.assets.manifest).map(async ([k, url]) => {
+      const tex = await glr.loadTexture(url);
+      World.assets.textures[k] = tex;
+    }),
+  );
+})();
+
+await World.buildTrackFromCSV('tracks/test-track.csv').catch(() => {
+  /* fallback like original */
+});
+await World.buildCliffsFromCSV_Lite('tracks/cliffs.csv').catch(() => {});
+World.enforceCliffWrap(1);
+
+const N = World.data.segments.length;
+const roadTexZones = [];
+const railTexZones = [];
+const cliffTexZones = [];
+World.pushZone(roadTexZones, 0, N - 1, 20);
+World.pushZone(railTexZones, 0, N - 1, 20);
+World.pushZone(cliffTexZones, 0, N - 1, 3);
+World.data.roadTexZones = roadTexZones;
+World.data.railTexZones = railTexZones;
+World.data.cliffTexZones = cliffTexZones;
+
+Gameplay.spawnProps();
+Gameplay.spawnCars();
+Gameplay.spawnPickups();
+Gameplay.resetPlayerState({
+  s: Config.TUNE_TRACK.camBackSegments * Config.TUNE_TRACK.segmentLength,
+  playerN: 0,
+  timers: { t: 0, nextHopTime: 0, boostFlashTimer: 0 },
+});
+
+addEventListener('keydown', Gameplay.keydownHandler);
+addEventListener('keyup', Gameplay.keyupHandler);
+
+Renderer.attach(glr, dom);
+Renderer.frame((dt) => {
+  Gameplay.step(dt);
+});


### PR DESCRIPTION
## Summary
- add a bootstrap module that wires the DOM, renderer, world, and gameplay systems together
- preload textures, build track data, initialize zones, and attach input and render loop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e20b24e088832d9c27a49da6e90d60