### PR TITLE
Handle GLRenderer canvas resizes

### DIFF
--- a/src/gl/renderer.js
+++ b/src/gl/renderer.js
@@ -57,6 +57,9 @@
       this.u_fogEnabled = gl.getUniformLocation(prog, 'u_fogEnabled');
       this.u_fogColor   = gl.getUniformLocation(prog, 'u_fogColor');
 
+      this._canvasWidth = canvas.width;
+      this._canvasHeight = canvas.height;
+
       // streaming slab
       this.vbo = gl.createBuffer();
       gl.bindBuffer(gl.ARRAY_BUFFER, this.vbo);
@@ -134,6 +137,13 @@
     begin(clear=[0.9,0.95,1.0,1]){
       const gl=this.gl;
       gl.viewport(0,0,gl.canvas.width,gl.canvas.height);
+      const width = gl.canvas.width;
+      const height = gl.canvas.height;
+      if (width !== this._canvasWidth || height !== this._canvasHeight) {
+        this._canvasWidth = width;
+        this._canvasHeight = height;
+        gl.uniform2f(this.u_viewSize, width, height);
+      }
       gl.clearColor(clear[0],clear[1],clear[2],clear[3]); gl.clear(gl.COLOR_BUFFER_BIT);
       gl.uniform2f(this.u_pivot, gl.canvas.width*0.5, gl.canvas.height*0.82);
       // Fog uniforms only when changed

--- a/test/glrenderer.resize.test.js
+++ b/test/glrenderer.resize.test.js
@@ -1,0 +1,62 @@
+const assert = (condition, message) => {
+  if (!condition) {
+    throw new Error(message);
+  }
+};
+
+global.window = {
+  Config: { fog: { enabled: false, color: [0, 0, 0] } },
+};
+
+require('../src/gl/renderer.js');
+
+const { GLRenderer } = window.RenderGL;
+
+const makeRenderer = (width, height) => {
+  const calls = [];
+  const gl = {
+    canvas: { width, height },
+    viewport: () => {},
+    clearColor: () => {},
+    clear: () => {},
+    uniform2f: (location, x, y) => {
+      calls.push(['uniform2f', location, x, y]);
+    },
+    uniform1i: () => {},
+    uniform3f: () => {},
+  };
+
+  const renderer = Object.create(GLRenderer.prototype);
+  renderer.gl = gl;
+  renderer.u_viewSize = Symbol('u_viewSize');
+  renderer.u_pivot = Symbol('u_pivot');
+  renderer.u_fogEnabled = Symbol('u_fogEnabled');
+  renderer.u_fogColor = Symbol('u_fogColor');
+  renderer._fogEnabled = null;
+  renderer._fogColor = [NaN, NaN, NaN];
+  renderer._canvasWidth = width;
+  renderer._canvasHeight = height;
+
+  return { renderer, calls, gl };
+};
+
+const { renderer, calls, gl } = makeRenderer(320, 240);
+
+renderer.begin();
+
+const firstViewUniformCalls = calls.filter((c) => c[0] === 'uniform2f' && c[1] === renderer.u_viewSize);
+assert(firstViewUniformCalls.length === 0, 'Unexpected view size update when dimensions did not change');
+
+calls.length = 0;
+gl.canvas.width = 640;
+gl.canvas.height = 360;
+
+renderer.begin();
+
+const updatedCalls = calls.filter((c) => c[0] === 'uniform2f' && c[1] === renderer.u_viewSize);
+assert(updatedCalls.length === 1, 'View size uniform should update when the canvas resizes');
+const [, , updatedWidth, updatedHeight] = updatedCalls[0];
+assert(updatedWidth === 640 && updatedHeight === 360, 'View size uniform should match new canvas dimensions');
+assert(renderer._canvasWidth === 640 && renderer._canvasHeight === 360, 'Cached canvas size should update after resize');
+
+console.log('GLRenderer resize smoke test passed.');


### PR DESCRIPTION
## Summary
- cache the current canvas dimensions on the GLRenderer instance
- refresh the view size uniform when the canvas resizes before rendering
- add a smoke test that exercises the resize path to keep quads aligned

## Testing
- node test/glrenderer.resize.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e21d87b678832dbb6fef13f7825e6e