### PR TITLE
Refine math utilities for clarity

### DIFF
--- a/src/math.js
+++ b/src/math.js
@@ -1,44 +1,69 @@
-const clamp01 = (t) => (t < 0 ? 0 : (t > 1 ? 1 : t));
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+const clamp01 = (value) => clamp(value, 0, 1);
 
-const easeLinear = (a,b,t)=> a + (b-a) * clamp01(t);
-const easeInQuad = (a,b,t)=> a + (b-a) * Math.pow(clamp01(t), 2);
-const easeOutQuad= (a,b,t)=> a + (b-a) * (1 - Math.pow(1 - clamp01(t), 2));
-const easeInCub  = (a,b,t)=> a + (b-a) * Math.pow(clamp01(t), 3);
-const easeOutCub = (a,b,t)=> a + (b-a) * (1 - Math.pow(1 - clamp01(t), 3));
+const lerp = (start, end, t) => start + (end - start) * t;
+const pctRem = (value, total) => (value % total) / total;
 
-const easeInOutQuad01 = (t)=> (t<0.5)? 2*t*t : 1 - Math.pow(-2*t+2,2)/2;
-const easeInOutCub01  = (t)=> (t<0.5)? 4*t*t*t : 1 - Math.pow(-2*t+2,3)/2;
-
-function getEase01(spec){
-  const clamp01 = (x)=> x<0?0:x>1?1:x;
-  const raw = (spec||'smooth:io').toLowerCase().trim();
-  const [kind, modeRaw] = raw.split(':');
-  const mode = (modeRaw||'io');
-  const K = {
-    linear: { in:(t)=>t, out:(t)=>t, io:(t)=>t },
-    smooth: { in:(t)=>Math.pow(clamp01(t),2), out:(t)=>1-Math.pow(1-clamp01(t),2), io:easeInOutQuad01 },
-    sharp:  { in:(t)=>Math.pow(clamp01(t),3), out:(t)=>1-Math.pow(1-clamp01(t),3), io:easeInOutCub01 },
-  };
-  return (K[kind]||K.smooth)[mode] || K.smooth.io;
-}
-
-const CURVE_EASE = {
-  linear: { in: easeLinear,  out: easeLinear },
-  smooth: { in: easeInQuad,  out: easeOutQuad },
-  sharp:  { in: easeInCub,   out: easeOutCub },
+const createEaseIn = (power) => (t) => Math.pow(clamp01(t), power);
+const createEaseOut = (power) => (t) => 1 - Math.pow(1 - clamp01(t), power);
+const createEaseInOut = (power) => (t) => {
+  const clamped = clamp01(t);
+  if (clamped <= 0.5) {
+    return Math.pow(clamped * 2, power) / 2;
+  }
+  return 1 - Math.pow((1 - clamped) * 2, power) / 2;
 };
 
-const pctRem=(n,total)=>(n%total)/total;
-const lerp=(a,b,t)=>a+(b-a)*t;
-const clamp=(v,min,max)=>Math.max(min,Math.min(max,v));
+const easeLinear01 = (t) => clamp01(t);
+const easeInQuad01 = createEaseIn(2);
+const easeOutQuad01 = createEaseOut(2);
+const easeInOutQuad01 = createEaseInOut(2);
+const easeInCub01 = createEaseIn(3);
+const easeOutCub01 = createEaseOut(3);
+const easeInOutCub01 = createEaseInOut(3);
 
-const computeCurvature=(dy,d2y)=> d2y/Math.pow(1+dy*dy,1.5);
-const tangentNormalFromSlope=(dy)=>{ const inv=1/Math.sqrt(1+dy*dy); return { tx:inv, ty:dy*inv, nx:-dy*inv, ny:inv }; };
+const createCurveEase = (fn01) => (start, end, t) => lerp(start, end, fn01(t));
+
+const easeLinear = createCurveEase(easeLinear01);
+const easeInQuad = createCurveEase(easeInQuad01);
+const easeOutQuad = createCurveEase(easeOutQuad01);
+const easeInCub = createCurveEase(easeInCub01);
+const easeOutCub = createCurveEase(easeOutCub01);
+
+const EASE_CURVES_01 = {
+  linear: { in: easeLinear01, out: easeLinear01, io: easeLinear01 },
+  smooth: { in: easeInQuad01, out: easeOutQuad01, io: easeInOutQuad01 },
+  sharp: { in: easeInCub01, out: easeOutCub01, io: easeInOutCub01 },
+};
+
+const getEase01 = (spec = "smooth:io") => {
+  const [curve = "smooth", mode = "io"] = spec.toLowerCase().trim().split(":");
+  const family = EASE_CURVES_01[curve] || EASE_CURVES_01.smooth;
+  return family[mode] || family.io;
+};
+
+const CURVE_EASE = {
+  linear: { in: easeLinear, out: easeLinear },
+  smooth: { in: easeInQuad, out: easeOutQuad },
+  sharp: { in: easeInCub, out: easeOutCub },
+};
+
+const computeCurvature = (dy, d2y) => d2y / Math.pow(1 + dy * dy, 1.5);
+
+const tangentNormalFromSlope = (dy) => {
+  const invLength = 1 / Math.sqrt(1 + dy * dy);
+  return {
+    tx: invLength,
+    ty: dy * invLength,
+    nx: -dy * invLength,
+    ny: invLength,
+  };
+};
 
 window.MathUtil = {
+  clamp,
   clamp01,
   lerp,
-  clamp,
   pctRem,
   easeLinear,
   easeInQuad,


### PR DESCRIPTION
## Summary
- refactor easing helpers to share reusable factory functions and consistent clamping
- simplify `getEase01` curve selection while keeping the same presets
- clarify curvature helpers with descriptive naming and structure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e220758a44832d943b69f7e637b69c