### PR TITLE
Refactor helpers to reduce code bloat

### DIFF
--- a/src/math.js
+++ b/src/math.js
@@ -4,6 +4,20 @@ const clamp01 = (value) => clamp(value, 0, 1);
 const lerp = (start, end, t) => start + (end - start) * t;
 const pctRem = (value, total) => (value % total) / total;
 
+const wrap = (value, length) => {
+  if (length <= 0) return value;
+  const mod = value % length;
+  return mod < 0 ? mod + length : mod;
+};
+
+const wrapIndex = (index, count) => {
+  if (count <= 0) return index;
+  const mod = index % count;
+  return mod < 0 ? mod + count : mod;
+};
+
+const wrapDistance = (value, delta, length) => wrap(value + delta, length);
+
 const createEaseIn = (power) => (t) => Math.pow(clamp01(t), power);
 const createEaseOut = (power) => (t) => 1 - Math.pow(1 - clamp01(t), power);
 const createEaseInOut = (power) => (t) => {
@@ -65,6 +79,9 @@ window.MathUtil = {
   clamp01,
   lerp,
   pctRem,
+  wrap,
+  wrapIndex,
+  wrapDistance,
   easeLinear,
   easeInQuad,
   easeOutQuad,

--- a/src/world.js
+++ b/src/world.js
@@ -12,10 +12,13 @@
   } = Config;
 
   const {
+    clamp,
     clamp01,
     lerp,
     getEase01,
     CURVE_EASE,
+    wrap,
+    wrapIndex,
   } = MathUtil;
 
   const assetManifest = {
@@ -34,11 +37,6 @@
   };
 
   const textures = {};
-
-  const clamp = (value, min, max) => {
-    if (value == null) return value;
-    return Math.min(Math.max(value, min), max);
-  };
 
   const parseNumber = (value, parser, fallback = 0) => {
     if (value === '' || value == null) return fallback;
@@ -605,17 +603,16 @@
 
   const segmentAtS = (s) => {
     if (!segments.length || trackLength <= 0) return null;
-    const wrapped = ((s % trackLength) + trackLength) % trackLength;
-    const idx = Math.floor(wrapped / segmentLength) % segments.length;
+    const wrapped = wrap(s, trackLength);
+    const idx = wrapIndex(Math.floor(wrapped / segmentLength), segments.length);
     return segments[idx];
   };
 
   function elevationAt(s){
     if (trackLength <= 0 || !segments.length) return 0;
-    let ss = s % trackLength;
-    if (ss < 0) ss += trackLength;
+    const ss = wrap(s, trackLength);
     const i = Math.floor(ss / segmentLength);
-    const seg = segments[i % segments.length];
+    const seg = segments[wrapIndex(i, segments.length)];
     const t = (ss - seg.p1.world.z) / segmentLength;
     return lerp(seg.p1.world.y, seg.p2.world.y, t);
   }
@@ -634,7 +631,7 @@
       };
     }
 
-    const segNorm = ((segIndex % segCount) + segCount) % segCount;
+    const segNorm = wrapIndex(segIndex, segCount);
     const u = clamp01(t);
     const total = totalSections;
     const global = segNorm * sectionsPerSeg + u * sectionsPerSeg;


### PR DESCRIPTION
## Summary
- centralize wrapping utilities in MathUtil and reuse them in gameplay and world modules
- simplify gameplay helpers for sprite metadata, key bindings, and random selections to cut repetition
- streamline world segment math by relying on shared helpers instead of inline calculations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24666ec38832d821ad12c8cca376d