### PR TITLE
Add fallback reset when matte unavailable

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -58,7 +58,15 @@ Renderer.frame((dt) => {
 const callbacks = Gameplay?.state?.callbacks;
 if (callbacks) {
   callbacks.onQueueReset = () => {
-    if (Renderer?.matte?.startReset) Renderer.matte.startReset();
+    const matte = Renderer?.matte;
+    if (matte?.startReset) {
+      matte.startReset();
+      if (!Gameplay?.state?.resetMatteActive) {
+        resetRace();
+      }
+    } else {
+      resetRace();
+    }
   };
   callbacks.onResetScene = () => {
     resetRace();


### PR DESCRIPTION
## Summary
- update the queue reset callback to fall back to resetRace when the matte reset animation cannot start
- keep the existing reset scene callback so resetRace still runs after matte-driven animations

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2539d30e8832d8bd74b0b0fb61922