### PR TITLE
Refactor shared world helpers

### DIFF
--- a/src/gameplay.js
+++ b/src/gameplay.js
@@ -26,7 +26,6 @@
   const {
     clamp,
     clamp01,
-    lerp,
     computeCurvature,
     tangentNormalFromSlope,
     wrap,
@@ -39,6 +38,10 @@
     roadWidthAt,
     floorElevationAt,
     cliffParamsAt,
+    segmentAtS,
+    elevationAt,
+    groundProfileAt,
+    boostZonesOnSegment,
     lane = {},
   } = World;
 
@@ -164,44 +167,9 @@
     return metaStack[kind] || DEFAULT_SPRITE_META[kind] || { wN: 0.2, aspect: 1, tint: [1, 1, 1, 1], tex: () => null };
   }
 
-  function segmentAtS(s) {
-    const length = trackLengthRef();
-    if (!hasSegments() || length <= 0) return null;
-    const wrapped = wrap(s, length);
-    const idx = wrapIndex(Math.floor(wrapped / segmentLength), segments.length);
-    return segments[idx];
-  }
-
   function segmentAtIndex(idx) {
     if (!hasSegments()) return null;
     return segments[wrapIndex(idx, segments.length)];
-  }
-
-  function elevationAt(s) {
-    const length = trackLengthRef();
-    if (!hasSegments() || length <= 0) return 0;
-    const ss = wrap(s, length);
-    const i = Math.floor(ss / segmentLength);
-    const seg = segments[wrapIndex(i, segments.length)];
-    const t = (ss - seg.p1.world.z) / segmentLength;
-    return lerp(seg.p1.world.y, seg.p2.world.y, t);
-  }
-
-  function groundProfileAt(s) {
-    const y = elevationAt(s);
-    if (!hasSegments()) return { y, dy: 0, d2y: 0 };
-    const h = Math.max(5, segmentLength * 0.1);
-    const y1 = elevationAt(s - h);
-    const y2 = elevationAt(s + h);
-    const dy = (y2 - y1) / (2 * h);
-    const d2y = (y2 - 2 * y + y1) / (h * h);
-    return { y, dy, d2y };
-  }
-
-  // Collect boost lane metadata for a segment.
-  function boostZonesOnSegment(seg) {
-    const zones = seg && seg.features ? seg.features.boostZones : null;
-    return Array.isArray(zones) ? zones : [];
   }
 
   // Check whether the player lateral position falls inside a zone.

--- a/src/render.js
+++ b/src/render.js
@@ -39,6 +39,10 @@
     floorElevationAt,
     cliffParamsAt,
     vSpanForSeg,
+    segmentAtS,
+    elevationAt,
+    groundProfileAt,
+    boostZonesOnSegment,
     lane = {},
   } = World;
 
@@ -317,43 +321,6 @@
     const shadowH = Math.max(2, hPx*0.06);
     const shQuad = {x1:x1, y1:y2-shadowH, x2:x2, y2:y2-shadowH, x3:x2, y3:y2, x4:x1, y4:y2};
     glr.drawQuadSolid(shQuad, [0,0,0,0.25], fog);
-  }
-
-  function segmentAtS(s) {
-    const length = getTrackLength();
-    if (!segments.length || length <= 0) return null;
-    let wrapped = s % length;
-    if (wrapped < 0) wrapped += length;
-    const idx = Math.floor(wrapped / segmentLength) % segments.length;
-    return segments[idx];
-  }
-
-  function elevationAt(s) {
-    const length = getTrackLength();
-    if (!segments.length || length <= 0) return 0;
-    let ss = s % length;
-    if (ss < 0) ss += length;
-    const i = Math.floor(ss / segmentLength);
-    const seg = segments[i % segments.length];
-    const t = (ss - seg.p1.world.z) / segmentLength;
-    return lerp(seg.p1.world.y, seg.p2.world.y, t);
-  }
-
-  function groundProfileAt(s) {
-    const y = elevationAt(s);
-    if (!segments.length) return { y, dy: 0, d2y: 0 };
-    const h = Math.max(5, segmentLength * 0.1);
-    const y1 = elevationAt(s - h);
-    const y2 = elevationAt(s + h);
-    const dy = (y2 - y1) / (2 * h);
-    const d2y = (y2 - 2 * y + y1) / (h * h);
-    return { y, dy, d2y };
-  }
-
-  function boostZonesOnSegment(seg) {
-    if (!seg || !seg.features) return [];
-    const zones = seg.features.boostZones;
-    return Array.isArray(zones) ? zones : [];
   }
 
   function zonesFor(key){

--- a/src/world.js
+++ b/src/world.js
@@ -617,6 +617,22 @@
     return lerp(seg.p1.world.y, seg.p2.world.y, t);
   }
 
+  function groundProfileAt(s){
+    const y = elevationAt(s);
+    if (trackLength <= 0 || !segments.length) return { y, dy: 0, d2y: 0 };
+    const h = Math.max(5, segmentLength * 0.1);
+    const y1 = elevationAt(s - h);
+    const y2 = elevationAt(s + h);
+    const dy = (y2 - y1) / (2 * h);
+    const d2y = (y2 - 2 * y + y1) / (h * h);
+    return { y, dy, d2y };
+  }
+
+  function boostZonesOnSegment(seg){
+    const zones = seg && seg.features ? seg.features.boostZones : null;
+    return Array.isArray(zones) ? zones : [];
+  }
+
   function cliffParamsAt(segIndex, t = 0){
     const segCount = segments.length;
     const sectionsPerSeg = CLIFF_SECTIONS_PER_SEG;
@@ -768,6 +784,10 @@
     enforceCliffWrap,
     floorElevationAt,
     cliffParamsAt,
+    segmentAtS,
+    elevationAt,
+    groundProfileAt,
+    boostZonesOnSegment,
     lane: {
       clampBoostLane,
       clampRoadLane,


### PR DESCRIPTION
## Summary
- expose shared groundProfileAt and boostZonesOnSegment helpers from the World module
- update gameplay and renderer code to use the shared World utilities instead of local copies

## Testing
- npm test *(fails: no package.json present)*

------
https://chatgpt.com/codex/tasks/task_e_68e255b00c3c832d91ed9b5b0a70cce3