### PR TITLE
Export shared cliff helpers from World and reuse gameplay logic

### DIFF
--- a/src/world.js
+++ b/src/world.js
@@ -784,6 +784,8 @@
     enforceCliffWrap,
     floorElevationAt,
     cliffParamsAt,
+    cliffSurfaceInfoAt,
+    cliffLateralSlopeAt,
     segmentAtS,
     elevationAt,
     groundProfileAt,


### PR DESCRIPTION
## Summary
- export `cliffSurfaceInfoAt` and `cliffLateralSlopeAt` through the `World` global so they can be reused
- drop the duplicated implementations from the gameplay module and rely on the shared helpers for tilt and cliff push logic

## Testing
- node test/glrenderer.resize.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2572deb40832d8aeafc0b8bb723c7