### PR TITLE
Expose shared track length accessor

### DIFF
--- a/src/gameplay.js
+++ b/src/gameplay.js
@@ -35,6 +35,7 @@
 
   const {
     data,
+    getTrackLength,
     roadWidthAt,
     floorElevationAt,
     cliffSurfaceInfoAt,
@@ -52,7 +53,6 @@
 
   const segments = data.segments;
   const segmentLength = track.segmentSize;
-  const trackLengthRef = () => data.trackLength || 0;
 
   const hasSegments = () => segments.length > 0;
 
@@ -351,7 +351,7 @@
         if (overlap(state.playerN, pHalf, car.offset, carHalfWN(car), 1)) {
           const capped = car.speed / Math.max(1, Math.abs(phys.vtan));
           phys.vtan = car.speed * capped;
-          phys.s = wrapDistance(car.z, -2, trackLengthRef());
+          phys.s = wrapDistance(car.z, -2, getTrackLength());
           break;
         }
       }
@@ -490,7 +490,7 @@
 
     phys.t += dt;
 
-    const length = trackLengthRef();
+    const length = getTrackLength();
     if (length > 0) {
       phys.s = wrap(phys.s, length);
     }
@@ -611,7 +611,7 @@
       const oldSeg = segmentAtS(car.z);
       const avoidance = steerAvoidance(car, oldSeg, playerSeg, playerHalfWN());
       car.offset += avoidance;
-      car.z = wrapDistance(car.z, dt * car.speed, trackLengthRef());
+      car.z = wrapDistance(car.z, dt * car.speed, getTrackLength());
       const newSeg = segmentAtS(car.z);
       if (oldSeg && newSeg && oldSeg !== newSeg) {
         const idx = oldSeg.cars.indexOf(car);
@@ -785,7 +785,7 @@
   }
 
   function respawnPlayerAt(sTarget, nNorm = 0) {
-    const length = trackLengthRef();
+    const length = getTrackLength();
     const sWrapped = wrap(sTarget, length);
     const seg = segmentAtS(sWrapped);
     const segIdx = seg ? seg.index : 0;

--- a/src/render.js
+++ b/src/render.js
@@ -34,6 +34,7 @@
 
   const {
     data,
+    getTrackLength,
     assets,
     roadWidthAt,
     floorElevationAt,
@@ -122,11 +123,6 @@
     const near = fogFactorFromZ(zNear);
     const far = fogFactorFromZ(typeof zFar === 'number' ? zFar : zNear);
     return [near, near, far, far];
-  }
-
-  function getTrackLength(){
-    const raw = data.trackLength;
-    return typeof raw === 'number' ? raw : (typeof raw === 'function' ? raw() : (raw || 0));
   }
 
   function projectPoint(p, camX, camY, camS){

--- a/src/world.js
+++ b/src/world.js
@@ -98,6 +98,7 @@
 
   const segments = [];
   let trackLength = 0;
+  const getTrackLength = () => trackLength;
   let boostZoneIdCounter = 0;
 
   const CLIFF_SECTIONS_PER_SEG = 4;
@@ -774,6 +775,7 @@
       segments,
       get trackLength(){ return trackLength; },
     },
+    getTrackLength,
     assets: { manifest: assetManifest, textures },
     loadTexturesWith,
     roadWidthAt,


### PR DESCRIPTION
## Summary
- add a shared World.getTrackLength() helper that exposes the current track length
- refactor gameplay and renderer modules to consume the shared accessor instead of local copies

## Testing
- npm test *(fails: missing package.json)*
- npm run build *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68e25863c0dc832da500526b49b3b22c