### PR TITLE
Add cliff drive limit and reuse guardrail braking logic

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -46,6 +46,7 @@ const cliffs = {
   pushStep: 0.5,
   distanceGain: 0.6,
   capPerFrame: 0.5,
+  driveLimitDeg: 60,  // maximum lateral slope angle before the car is forced back on-road
   cameraBlend: 1 / 3,
 };
 


### PR DESCRIPTION
## Summary
- add a configurable cliff drive angle limit alongside existing push tuning
- reuse the guard-rail clamp/brake helper for both rails and steep cliff edges
- compute the cliff push using surface info so steep slopes clamp the player back toward the road

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e263eeea80832dab4e709b6a19de63