### PR TITLE
Scale cliff pushback by drop height

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -43,10 +43,12 @@ const camera = {
 
 // Cliff behaviour and camera bias when approaching drops.
 const cliffs = {
-  pushStep: 0.5,
-  distanceGain: 0.6,
+  pushStep: 0.5,         // base lateral push rate before distance/height scaling
+  distanceGain: 0.6,     // extra push from deeper offsets; multiplies with heightPushScale
+  heightPushScale: 0.002, // multiplier per unit of cliff height contributing to pushback
+  heightPushMax: 3.0,    // clamp for the height-based multiplier so pushStep stays stable
   capPerFrame: 0.5,
-  driveLimitDeg: 60,  // maximum lateral slope angle before the car is forced back on-road
+  driveLimitDeg: 60,     // maximum lateral slope angle before the car is forced back on-road
   cameraBlend: 1 / 3,
 };
 


### PR DESCRIPTION
## Summary
- scale cliff pushback using the sampled drop height so taller cliffs push harder
- add height tuning controls to the cliff config and document how they interact with distance gain

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e26d132948832da973de75f2b48793