### PR TITLE
Adjust cliff push height multiplier

### DIFF
--- a/src/gameplay.js
+++ b/src/gameplay.js
@@ -328,7 +328,7 @@
     const s = Math.max(0, Math.min(1.5, ax - 1));
     const gain = 1 + cliffs.distanceGain * s;
     const heightScale = Math.max(0, cliffs.heightPushScale ?? 0);
-    const heightSample = Math.abs(heightOffset) * clamp01(sectionCoverage || 0);
+    const heightSample = Math.abs(heightOffset);
     const heightMul = heightScale > 0
       ? clamp(1 + heightSample * heightScale, 1, Math.max(1, cliffs.heightPushMax ?? 3))
       : 1;


### PR DESCRIPTION
## Summary
- change cliff push force height scaling to rely solely on the sampled height offset
- retain the existing clamp so taller cliffs can reach the configured maximum push multiplier

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e27a304ea8832dbdb77bfa48658735