### PR TITLE
Revert cliff gameplay adjustments to drawBoostZones baseline

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -43,13 +43,9 @@ const camera = {
 
 // Cliff behaviour and camera bias when approaching drops.
 const cliffs = {
-  pushStep: 0.5,         // base lateral push rate before distance/height scaling
-  distanceGain: 0.6,     // extra push from deeper offsets; multiplies with heightPushScale
-  heightPushScale: 0.002, // multiplier per unit of cliff height contributing to pushback
-  heightPushMax: 3.0,    // clamp for the height-based multiplier so pushStep stays stable
+  pushStep: 0.5,
+  distanceGain: 0.6,
   capPerFrame: 0.5,
-  driveLimitDeg: 60,     // maximum lateral slope angle before the car is forced back on-road
-  guardrailHeight: 60,   // minimum cliff drop height before invisible guardrail slows the player
   cameraBlend: 1 / 3,
 };
 

--- a/tracks/cliffs.csv
+++ b/tracks/cliffs.csv
@@ -1,10 +1,6 @@
 # side,len,aEase,aDx,aDy,bEase,bDx,bDy,mode,repeats
-# Demonstration of mixed cliff terraces, valleys, and wrap-safe resets.
-B,32,linear:io, 7000,0, linear:io,0,0, abs,1
-L,20,smooth:in, -2200,-3200, smooth:out, -2800,-5200, rel,1
-L,12,sharp:io, 1200,2800, smooth:io, 1800,4200, rel,1
-R,16,sharp:in, 2400,5000, sharp:out, 2600,6200, rel,1
-R,12,smooth:out, -3600,-7000, smooth:in, -2200,-4800, rel,1
-B,10,smooth:io, -1800,-1500, smooth:io, 1600,1500, rel,2
-B,18,sharp:io, 0,4000, sharp:io,0,3200, rel,1
-B,8,linear:io, 7000,0, linear:io,0,0, abs,1
+# Baseline geometry for each side
+L,40,linear:io, 3000,000,     linear:io, 60000,0,  abs,1
+R,40,linear:io, 3000,1000,  linear:io,60000,0,    abs,1
+L,41,linear:io, 0,3000,     linear:io, -2500,0,  abs,1
+R,41,linear:io, 0,3000,  linear:io,-2500,0,    abs,1

--- a/tracks/test-track.csv
+++ b/tracks/test-track.csv
@@ -1,20 +1,12 @@
 # Columns: type,enter,hold,leave,curve,dy,railpresent,boostStart,boostEnd,repeats,boostType,boostLaneStart,boostLaneEnd,boostVisible[,comment]
-# Demo track showcasing varied hills, curves, straights, boosts, and guardrail layouts. Height ends where it begins.
-# Set railpresent=false to drop guardrails for that build step. Hill types: smoothHill (eased), sharpHill (mirrored sharp), straight (linear grade).
+# Set railpresent=false to drop guardrails for that build step. Hill types: smoothHill (eased), smoothHill (mirrored sharp), straight (linear grade).
 # Provide a boost window via boostStart/boostEnd (segment offsets within the generated block) to auto-spawn pickups and apply the boost multiplier. Use boostStart=0 and boostEnd=0 to skip spawning a boost zone for that row.
 # Optional boostType column accepts "jump" (orange hop boost) or "drive" (blue drive-over boost). Provide boostLaneStart/boostLaneEnd values to constrain the boost zone laterally using player-normalized coordinates (-2 at far left, +2 at far right).
-straight,20,40,20,0,0,true,0,0,1,,,,,Warm-up straight with full guardrails
-smoothHill,24,32,24,0,5,true,0,0,1,,,,,Gentle smooth climb
-straight,12,24,12,0,0,true,4,28,1,drive,-0.5,0.5,true,Mid-plateau with centred drive boost
-smoothHill,24,32,24,0,-5,true,0,0,1,,,,,Matching smooth descent back to base elevation
-sharpHill,12,16,12,0,4,true,0,0,1,,,,,Sharp crest rising toward lookout
-straight,6,12,6,0,0,false,0,0,1,,,,,Scenic straight without guardrails
-sharpHill,12,16,12,0,-4,true,0,0,1,,,,,Sharp drop into valley floor
-smoothHill,6,8,6,0,1,true,0,0,1,,,,,Small bump jump setup
-smoothHill,6,8,6,0,-1,true,0,0,1,,,,,Small bump landing
-curve,10,20,10,30,0,true,0,0,1,,,,,Sweeping left curve with gentle grade
-curve,10,14,10,-32,0,false,2,12,1,jump,1,2,true,Cliffside right hairpin with jump boost
-curve,4,8,4,18,0,true,0,0,1,,,,,Quick left flick entering chicane
-curve,4,8,4,-18,0,true,0,0,1,,,,,Quick right flick
-curve,4,8,4,12,0,true,0,0,1,,,,,Left exit from chicane
-straight,12,24,12,0,0,true,8,20,1,jump,-2,-0.5,true,Final straight with outer-lane jump pads
+straight,30,30,30,0,0,false,2,30,1,
+straight,4,4,4,0,4,false,2,30,1,
+straight,4,4,4,0,-4,false,2,30,1,
+straight,30,30,30,0,0,false,2,30,1,
+straight,200,200,200,20,-120,true,2,30,1,
+straight,30,30,30,0,0,false,2,30,1,
+straight,30,30,30,-10,0,false,2,30,1,
+straight,30,30,30,0,0,false,2,30,1,


### PR DESCRIPTION
## Summary
- revert gameplay, world, and config to the state from the drawBoostZonesOnStrip refactor
- restore the earlier cliff and test track CSV data prior to recent guardrail and pushback changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3ae2f39d8832d91673949a6c3afc7