### PR TITLE
Simplify gameplay physics by removing cliff influence

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -41,14 +41,6 @@ const camera = {
   heightEase: 0.1,
 };
 
-// Cliff behaviour and camera bias when approaching drops.
-const cliffs = {
-  pushStep: 0.5,
-  distanceGain: 0.6,
-  capPerFrame: 0.5,
-  cameraBlend: 1 / 3,
-};
-
 // Guard rails for falling through the world.
 const failsafe = {
   dropUnits: 600,
@@ -141,7 +133,6 @@ window.Config = {
   grid,
   track,
   camera,
-  cliffs,
   failsafe,
   fog,
   colors,

--- a/src/world.js
+++ b/src/world.js
@@ -756,18 +756,8 @@
     return { heightOffset, slope: 0, section: null, slopeA, slopeB, coverageA, coverageB };
   }
 
-  function floorElevationAt(s, nNorm){
-    const base = elevationAt(s);
-    const seg = segmentAtS(s);
-    if (!seg) return base;
-    const segT = clamp01((s - seg.p1.world.z) / segmentLength);
-    const info = cliffSurfaceInfoAt(seg.index, nNorm, segT);
-    return base + info.heightOffset;
-  }
-
-  function cliffLateralSlopeAt(segIndex, nNorm, t = 0){
-    const info = cliffSurfaceInfoAt(segIndex, nNorm, t);
-    return info.slope;
+  function floorElevationAt(s){
+    return elevationAt(s);
   }
 
   global.World = {
@@ -787,7 +777,6 @@
     floorElevationAt,
     cliffParamsAt,
     cliffSurfaceInfoAt,
-    cliffLateralSlopeAt,
     segmentAtS,
     elevationAt,
     groundProfileAt,


### PR DESCRIPTION
## Summary
- remove unused cliff configuration that only drove cliff-based physics adjustments
- streamline gameplay physics to ignore cliff surface sampling and rely on the road profile for camera and failsafe logic
- simplify the world floor sampler to return raw track elevation now that cliffs are purely cosmetic

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e3b64cbc70832d97d2310c1a33b6a9