### PR TITLE
Fix debug cross-section sampling

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -938,7 +938,7 @@
     const step   = Math.max(5, 2*track.metersPerPixel.x);
     let first = true;
     for (let s = sStart; s <= sEnd; s += step){
-      const p = worldToOverlay(s, floorElevationAt(s, state.playerN));
+      const p = worldToOverlay(s, elevationAt(s));
       if (first){ ctxSide.moveTo(p.x,p.y); first=false; } else { ctxSide.lineTo(p.x,p.y); }
     }
     ctxSide.stroke();


### PR DESCRIPTION
## Summary
- adjust the debug overlay cross-section to sample only the road elevation, matching the monolith behavior when off-road

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c553b0a4832dacbe6fc2b268d7a0