### PR TITLE
Add build version metadata to debug overlay

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,8 @@
+// Build metadata for tracking deployed versions.
+const build = Object.freeze({
+  version: '0.1.0',
+});
+
 // Core handling and tuning for the player car.
 const player = {
   accelForce: 3000,     // forward push strength
@@ -137,6 +142,7 @@ const tilt = {
 };
 
 window.Config = {
+  build,
   player,
   grid,
   track,

--- a/src/render.js
+++ b/src/render.js
@@ -18,6 +18,7 @@
     boost,
     drift,
     tilt: tiltConfig = {},
+    build = {},
   } = Config;
 
   const {
@@ -953,7 +954,11 @@
     const kap = computeCurvature(dy, d2y);
     const boostingHUD = (state.boostTimer>0) ? `boost:${state.boostTimer.toFixed(2)}s ` : '';
     const driftHUD = `drift:${state.driftState}${state.driftState==='drifting'?' dir='+state.driftDirSnapshot:''} charge:${state.driftCharge.toFixed(2)}/${drift.chargeMin} armed:${state.allowedBoost}`;
-    const hud = `${boostingHUD}${driftHUD}  vtan:${state.phys.vtan.toFixed(1)}  grounded:${state.phys.grounded}  kappa:${kap.toFixed(5)}  n:${state.playerN.toFixed(2)}  cars:${state.cars.length}  pickups:${state.pickupCollected}/${state.pickupTotal}`;
+    const buildVersion = (typeof build.version === 'string' && build.version.length > 0)
+      ? build.version
+      : null;
+    const versionHUD = buildVersion ? `ver:${buildVersion}  ` : '';
+    const hud = `${versionHUD}${boostingHUD}${driftHUD}  vtan:${state.phys.vtan.toFixed(1)}  grounded:${state.phys.grounded}  kappa:${kap.toFixed(5)}  n:${state.playerN.toFixed(2)}  cars:${state.cars.length}  pickups:${state.pickupCollected}/${state.pickupTotal}`;
     ctxSide.fillStyle = '#fff';
     ctxSide.strokeStyle = '#000';
     ctxSide.lineWidth = 3;


### PR DESCRIPTION
## Summary
- add a frozen build metadata object with the current version number to the shared configuration
- display the configured version string at the front of the debug overlay HUD so updates are visible during debugging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4f46ff4f8832da418e5582a484a0f