### PR TITLE
Improve car collision handling and segment traversal

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -142,6 +142,8 @@ const tilt = {
   additive: { tiltAddEnabled: true, tiltAddMaxDeg: null },
 };
 
+const forceLandingOnCarImpact = false;
+
 window.Config = {
   build,
   player,
@@ -159,6 +161,7 @@ window.Config = {
   boost,
   lanes,
   tilt,
+  forceLandingOnCarImpact,
 };
 
 Object.freeze(window.Config);


### PR DESCRIPTION
## Summary
- update the car collision response to sync airborne and ground velocities, add a collision cooldown, and support optional forced landing
- walk every traversed segment during integration so car and pickup checks trigger reliably across segment boundaries
- expose a forceLandingOnCarImpact configuration flag to control bumper "stick" behaviour

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e665d88a14832db747330880b27b62