### PR TITLE
Add configurable traffic density for road NPCs

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -95,6 +95,13 @@ const parallaxLayers = [
   { key: 'horizon3', parallaxX: 0.18, uvSpanX: 1.0, uvSpanY: 1.0 },
 ];
 
+// Road traffic tuning for non-player cars.
+const traffic = {
+  total: 20,
+  edgePad: 0.02,
+  avoidLookaheadSegs: 20,
+};
+
 // Drift boost tuning.
 const drift = {
   chargeMin: 0.6,
@@ -157,6 +164,7 @@ window.Config = {
   debug,
   sprites,
   parallaxLayers,
+  traffic,
   drift,
   boost,
   lanes,

--- a/src/gameplay.js
+++ b/src/gameplay.js
@@ -16,6 +16,7 @@
     boost,
     lanes,
     tilt: tiltConfig = {},
+    traffic: trafficConfig = {},
     forceLandingOnCarImpact = false,
   } = Config;
 
@@ -83,7 +84,8 @@
     PICKUP: { wN: 0.10, aspect: 1.0, tint: [1, 0.92, 0.2, 1], tex: () => null },
   };
 
-  const NPC = { total: 20, edgePad: 0.02, avoidLookaheadSegs: 20 };
+  const NPC_DEFAULTS = { total: 20, edgePad: 0.02, avoidLookaheadSegs: 20 };
+  const NPC = { ...NPC_DEFAULTS, ...trafficConfig };
   const CAR_TYPES = ['CAR', 'SEMI'];
 
   const CAR_COLLISION_COOLDOWN = 1 / 120;


### PR DESCRIPTION
## Summary
- add a traffic configuration block to control NPC spawn parameters
- respect the configurable traffic settings when initializing gameplay NPC values

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e670050540832dba3f00d4ad10e515