### PR TITLE
Anchor snowfall animation to world segments

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -74,6 +74,7 @@ const snowfall = {
   flakesPerGroup: 24,
   endSegments: 20,
   density: 0.65,
+  segmentPhaseStride: 1.5,
 };
 
 // Default fallback tint values for world primitives.

--- a/src/render.js
+++ b/src/render.js
@@ -73,11 +73,21 @@
 
   const TAU = Math.PI * 2;
 
+  function hash01(seedA, seedB = 0){
+    const x = Math.sin((seedA + 1) * 127.1 + (seedB + 1) * 311.7) * 43758.5453;
+    return x - Math.floor(x);
+  }
+
+  function hashRange(seedA, seedB, min, max){
+    return lerp(min, max, hash01(seedA, seedB));
+  }
+
   const SNOW_DEFAULTS = {
     enabled: false,
     flakesPerGroup: 24,
     endSegments: 20,
     density: 0.5,
+    segmentPhaseStride: 1.5,
   };
 
   const snowState = {
@@ -86,6 +96,8 @@
     lastT: null,
     config: { ...SNOW_DEFAULTS },
     density: SNOW_DEFAULTS.density,
+    segmentCycle: 0,
+    lastBaseIndex: null,
   };
 
   let glr = null;
@@ -114,11 +126,15 @@
     const flakesRaw = Number.isFinite(base.flakesPerGroup) ? base.flakesPerGroup : SNOW_DEFAULTS.flakesPerGroup;
     const endRaw = Number.isFinite(base.endSegments) ? base.endSegments : SNOW_DEFAULTS.endSegments;
     const densityRaw = typeof base.density === 'number' ? base.density : SNOW_DEFAULTS.density;
+    const phaseStrideRaw = typeof base.segmentPhaseStride === 'number'
+      ? base.segmentPhaseStride
+      : SNOW_DEFAULTS.segmentPhaseStride;
     snowState.config = {
       enabled,
       flakesPerGroup: Math.max(0, Math.floor(flakesRaw)),
       endSegments: Math.max(0, Math.floor(endRaw)),
       density: clamp(densityRaw, 0, 1),
+      segmentPhaseStride: phaseStrideRaw,
     };
     snowState.density = snowState.config.density;
   }
@@ -130,19 +146,22 @@
     }
   }
 
-  function createSnowflakes(count){
+  function createSnowflakes(count, seedBase){
     const flakes = [];
+    const base = Number.isFinite(seedBase) ? seedBase : Math.random() * 1e6;
+    const step = 17.23;
     for (let i = 0; i < count; i++) {
+      const seed = base + i * step;
       flakes.push({
-        seedX: Math.random(),
-        seedY: Math.random(),
-        radiusN: lerp(0.004, 0.012, Math.random()),
-        fallSpeed: lerp(0.2, 0.55, Math.random()),
-        swayAmp: lerp(0.015, 0.06, Math.random()),
-        swaySpeed: lerp(0.25, 0.9, Math.random()),
-        drift: lerp(-0.02, 0.02, Math.random()),
-        opacity: lerp(0.35, 0.85, Math.random()),
-        phase: Math.random() * TAU,
+        seedX: hash01(seed, 0),
+        seedY: hash01(seed, 1),
+        radiusN: hashRange(seed, 2, 0.004, 0.012),
+        fallSpeed: hashRange(seed, 3, 0.2, 0.55),
+        swayAmp: hashRange(seed, 4, 0.015, 0.06),
+        swaySpeed: hashRange(seed, 5, 0.25, 0.9),
+        drift: hashRange(seed, 6, -0.02, 0.02),
+        opacity: hashRange(seed, 7, 0.35, 0.85),
+        phase: hashRange(seed, 8, 0, TAU),
       });
     }
     return flakes;
@@ -152,11 +171,12 @@
     return {
       index,
       time: Math.random() * 10,
-      offset: Math.random(),
+      offset: 0,
       speed: lerp(0.85, 1.15, Math.random()),
-      scroll: Math.random(),
+      scroll: 0,
       scrollRate: lerp(-0.12, 0.12, Math.random()),
       flakes: createSnowflakes(flakeCount),
+      anchorId: null,
     };
   }
 
@@ -177,12 +197,53 @@
     }
   }
 
+  function resetSnowAnchors(){
+    snowState.segmentCycle = 0;
+    snowState.lastBaseIndex = null;
+    for (const plane of snowState.planes) {
+      if (!plane) continue;
+      plane.anchorId = null;
+    }
+  }
+
+  function seedSnowPlaneForSegment(plane, segAbsIndex, flakeCount){
+    if (!plane) return;
+    const needsReseed = plane.anchorId !== segAbsIndex || !Array.isArray(plane.flakes) || plane.flakes.length !== flakeCount;
+    if (!needsReseed) return;
+    plane.anchorId = segAbsIndex;
+    plane.offset = hashRange(segAbsIndex, 9, 0, 16);
+    plane.scroll = hash01(segAbsIndex, 10);
+    plane.flakes = createSnowflakes(flakeCount, segAbsIndex);
+  }
+
+  function updateSnowBaseIndex(currentIndex){
+    if (!snowState.config.enabled || !segments.length) {
+      resetSnowAnchors();
+      return currentIndex;
+    }
+    if (!Number.isFinite(snowState.segmentCycle)) snowState.segmentCycle = 0;
+    if (snowState.lastBaseIndex == null) {
+      snowState.lastBaseIndex = currentIndex;
+      return currentIndex + snowState.segmentCycle * segments.length;
+    }
+    const segCount = segments.length;
+    const delta = currentIndex - snowState.lastBaseIndex;
+    if (delta > segCount / 2) {
+      snowState.segmentCycle -= 1;
+    } else if (delta < -segCount / 2) {
+      snowState.segmentCycle += 1;
+    }
+    snowState.lastBaseIndex = currentIndex;
+    return currentIndex + snowState.segmentCycle * segCount;
+  }
+
   function tickSnowSystem(){
     const cfg = snowState.config;
     snowState.density = cfg.density;
     if (!cfg.enabled) {
       snowState.lastT = state.phys.t;
       snowState.planes.length = 0;
+      resetSnowAnchors();
       return;
     }
 
@@ -194,6 +255,7 @@
     const planeCount = Math.min(track.drawDistance, cfg.endSegments);
     if (planeCount <= 0) {
       snowState.planes.length = 0;
+      resetSnowAnchors();
       return;
     }
 
@@ -530,7 +592,8 @@
       cliff: zonesFor('cliff'),
     };
 
-    const drawList = buildWorldDrawList(baseSeg, basePct, frame, zoneData);
+    const baseAbsIndex = updateSnowBaseIndex(baseSeg.index);
+    const drawList = buildWorldDrawList(baseSeg, basePct, frame, zoneData, baseAbsIndex);
     enqueuePlayer(drawList, frame);
 
     drawList.sort((a, b) => b.depth - a.depth);
@@ -570,7 +633,7 @@
     state.playerTiltDeg += (cliffDeg - state.playerTiltDeg) * 0.35;
   }
 
-  function buildWorldDrawList(baseSeg, basePct, frame, zoneData){
+  function buildWorldDrawList(baseSeg, basePct, frame, zoneData, baseAbsIndex){
     const { sCam, camX, camY } = frame;
     const drawList = [];
     const trackLength = getTrackLength();
@@ -604,11 +667,15 @@
       if (snowState.config.enabled && n < snowState.planes.length) {
         const plane = snowState.planes[n];
         if (plane) {
+          const segAbsIndex = baseAbsIndex + n;
+          seedSnowPlaneForSegment(plane, segAbsIndex, snowState.config.flakesPerGroup);
+          const segmentTravel = segAbsIndex - (baseAbsIndex + basePct);
           drawList.push({
             type: 'snow',
             depth: depth - 1e-3,
             plane,
             segDepth: depth,
+            segmentTravel,
           });
         }
       }
@@ -845,7 +912,7 @@
   }
 
   function renderSnowPlane(item){
-    const { plane, segDepth } = item;
+    const { plane, segDepth, segmentTravel = 0 } = item;
     if (!plane || !glr || !snowState.circleTex) return;
     if (!Array.isArray(plane.flakes) || plane.flakes.length === 0) return;
 
@@ -859,8 +926,12 @@
     const height = H;
     if (width <= 0 || height <= 0) return;
     const scaleRef = Math.min(width, height);
-    const time = (plane.time % 4096) + plane.offset;
-    const scroll = plane.scroll || 0;
+    const cfg = snowState.config;
+    const segmentPhase = (cfg.segmentPhaseStride || 0) * segmentTravel;
+    const time = (plane.time % 4096) + plane.offset + segmentPhase;
+    let scroll = plane.scroll || 0;
+    scroll += segmentTravel * 0.05;
+    scroll -= Math.floor(scroll);
 
     for (const flake of plane.flakes) {
       if (!flake) continue;
@@ -868,7 +939,7 @@
       const fallPhase = fallPhaseRaw - Math.floor(fallPhaseRaw);
       const y = fallPhase * height;
 
-      const swayPhase = plane.time * flake.swaySpeed * TAU + flake.phase;
+      const swayPhase = (plane.time + segmentPhase) * flake.swaySpeed * TAU + flake.phase;
       let xNorm = flake.seedX + Math.sin(swayPhase) * flake.swayAmp + scroll * flake.drift;
       xNorm -= Math.floor(xNorm);
       const x = xNorm * width;


### PR DESCRIPTION
## Summary
- tie snowfall animation phase to world segment position so flakes change as the player moves forward
- deterministically reseed snow planes per segment to create consistent world-space snowfall patterns
- add configuration for snow phase stride and preserve per-lap continuity with segment cycle tracking

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e67f9f3988832d937054cc6c19f0f0