### PR TITLE
Flatten sprite catalog definition and remove sprite shadows

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -449,7 +449,6 @@
     tint = [1, 1, 1, 1],
     texture = null,
     uvOverride = null,
-    drawShadow = true,
     anchor = SPRITE_ANCHOR.BOTTOM_CENTER,
   ){
     if (!glr) return;
@@ -471,11 +470,6 @@
     const quad = {x1:x1, y1:y1, x2:x2, y2:y1, x3:x2, y3:y2, x4:x1, y4:y2};
     if (texture) glr.drawQuadTextured(texture, quad, uv, tint, fog);
     else         glr.drawQuadSolid(quad, tint, fog);
-    if (drawShadow){
-      const shadowH = Math.max(2, hPx*0.06);
-      const shQuad = {x1:x1, y1:y2-shadowH, x2:x2, y2:y2-shadowH, x3:x2, y3:y2, x4:x1, y4:y2};
-      glr.drawQuadSolid(shQuad, [0,0,0,0.25], fog);
-    }
   }
 
   function segmentAtS(s) {
@@ -854,7 +848,6 @@
           tint: meta.tint,
           tex: texture,
           uv,
-          drawShadow: spr && spr.castShadow !== false,
           anchor,
         });
       }
@@ -898,7 +891,6 @@
     const floor = floorElevationAt(phys.s, state.playerN);
     const bodyWorldY = phys.grounded ? floor : phys.y;
     const body = projectWorldPoint({ x: carX, y: bodyWorldY, z: phys.s }, camX, camY, sCam);
-    const shadow = projectWorldPoint({ x: carX, y: floor, z: phys.s }, camX, camY, sCam);
     if (body.camera.z > state.camera.nearZ){
       const pixScale = body.screen.scale * HALF_VIEW;
       const w = Math.max(
@@ -913,9 +905,7 @@
         w,
         h,
         bodyY: body.screen.y,
-        shadowY: shadow.screen.y,
         zBody: body.camera.z,
-        zShadow: shadow.camera.z,
       });
     }
   }
@@ -935,7 +925,6 @@
           item.tint,
           item.tex,
           item.uv,
-          item.drawShadow !== false,
           item.anchor,
         );
       } else if (item.type === 'pickup'){
@@ -948,7 +937,6 @@
           item.tint,
           item.tex,
           item.uv,
-          true,
           item.anchor,
         );
       } else if (item.type === 'snowScreen'){
@@ -1180,21 +1168,13 @@
   }
 
   function renderPlayer(item, SPRITE_META){
-    const fogShadow = fogArray(item.zShadow || 0);
     const fogBody = fogArray(item.zBody || 0);
-    const shH = Math.max(3, item.h * 0.06);
-
-    const bodyBottom = Math.min(item.bodyY, item.shadowY - shH);
+    const bodyBottom = item.bodyY;
     const bodyTop = bodyBottom - item.h;
     const bodyCX = item.x;
     const bodyCY = (bodyTop + bodyBottom) * 0.5;
-    const shCX = item.x;
-    const shCY = item.shadowY - shH * 0.5;
 
     const ang = (state.playerTiltDeg * Math.PI) / 180;
-
-    const shQuad = makeRotatedQuad(shCX, shCY, item.w, shH, ang);
-    glr.drawQuadSolid(shQuad, [0.13, 0.13, 0.13, 1], fogShadow);
 
     const bodyQuad = makeRotatedQuad(bodyCX, bodyCY, item.w, item.h, ang);
     glr.drawQuadSolid(bodyQuad, SPRITE_META.PLAYER.tint, fogBody);

--- a/src/sprite-catalog.js
+++ b/src/sprite-catalog.js
@@ -37,9 +37,8 @@
     return frames;
   }
 
-  const CATALOG_SOURCE = [
-    {
-      spriteId: 'tree_main',
+  const CATALOG_SOURCE = Object.freeze({
+    tree_main: {
       metrics: {
         wN: 0.5,
         aspect: 3.0,
@@ -47,17 +46,14 @@
         textureKey: 'tree',
         atlas: null,
       },
-      assets: [
-        { type: 'texture', key: 'tree', frames: [] },
-      ],
+      assets: [{ type: 'texture', key: 'tree', frames: [] }],
       type: 'static',
       interaction: 'static',
       baseClip: { frames: [], playback: 'none' },
       interactClip: { frames: [], playback: 'none' },
       frameDuration: null,
     },
-    {
-      spriteId: 'palm_main',
+    palm_main: {
       metrics: {
         wN: 0.38,
         aspect: 3.2,
@@ -65,17 +61,14 @@
         textureKey: 'tree',
         atlas: null,
       },
-      assets: [
-        { type: 'texture', key: 'tree', frames: [] },
-      ],
+      assets: [{ type: 'texture', key: 'tree', frames: [] }],
       type: 'static',
       interaction: 'static',
       baseClip: { frames: [], playback: 'none' },
       interactClip: { frames: [], playback: 'none' },
       frameDuration: null,
     },
-    {
-      spriteId: 'rockwall_sign',
+    rockwall_sign: {
       metrics: {
         wN: 1.2,
         aspect: 1.0,
@@ -83,17 +76,14 @@
         textureKey: 'sign',
         atlas: { columns: 4, totalFrames: 16 },
       },
-      assets: [
-        { type: 'atlas', key: 'sign', frames: makeFrames(0, 15) },
-      ],
+      assets: [{ type: 'atlas', key: 'sign', frames: makeFrames(0, 15) }],
       type: 'static',
       interaction: 'static',
       baseClip: { frames: [], playback: 'none' },
       interactClip: { frames: [], playback: 'none' },
       frameDuration: null,
     },
-    {
-      spriteId: 'anim_plate_drive',
+    anim_plate_drive: {
       metrics: {
         wN: 0.1,
         aspect: 1.0,
@@ -101,17 +91,14 @@
         textureKey: 'animPlate01',
         atlas: { columns: 4, totalFrames: 16 },
       },
-      assets: [
-        { type: 'atlas', key: 'animPlate01', frames: makeFrames(0, 15) },
-      ],
+      assets: [{ type: 'atlas', key: 'animPlate01', frames: makeFrames(0, 15) }],
       type: 'trigger',
       interaction: 'playAnim',
       baseClip: { frames: [], playback: 'none' },
       interactClip: { frames: makeFrames(0, 15), playback: 'loop' },
       frameDuration: 0.08,
     },
-    {
-      spriteId: 'anim_plate_alt',
+    anim_plate_alt: {
       metrics: {
         wN: 0.1,
         aspect: 1.0,
@@ -119,19 +106,17 @@
         textureKey: 'animPlate02',
         atlas: { columns: 4, totalFrames: 16 },
       },
-      assets: [
-        { type: 'atlas', key: 'animPlate02', frames: makeFrames(0, 15) },
-      ],
+      assets: [{ type: 'atlas', key: 'animPlate02', frames: makeFrames(0, 15) }],
       type: 'trigger',
       interaction: 'playAnim',
       baseClip: { frames: [], playback: 'none' },
       interactClip: { frames: makeFrames(0, 15), playback: 'loop' },
       frameDuration: 0.08,
     },
-  ];
+  });
 
   const CATALOG_MAP = new Map();
-  for (const entry of CATALOG_SOURCE) {
+  for (const [spriteId, entry] of Object.entries(CATALOG_SOURCE)) {
     const metrics = entry.metrics ? Object.freeze({
       wN: entry.metrics.wN,
       aspect: entry.metrics.aspect,
@@ -152,7 +137,7 @@
       : [];
 
     const frozen = Object.freeze({
-      spriteId: entry.spriteId,
+      spriteId,
       metrics,
       assets,
       type: entry.type || 'static',
@@ -162,7 +147,7 @@
       frameDuration: entry.frameDuration,
     });
 
-    CATALOG_MAP.set(entry.spriteId, frozen);
+    CATALOG_MAP.set(spriteId, frozen);
   }
 
   function cloneCatalog(){


### PR DESCRIPTION
## Summary
- restructured the sprite catalog source into a keyed object for a flatter, easier-to-scan layout
- removed billboard and player sprite shadow rendering so sprites draw without drop shadows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f36f0370a0832da5f8c97b2f11436b